### PR TITLE
Add Wizards & Shadows manifest and entry module

### DIFF
--- a/foundryvtt.json
+++ b/foundryvtt.json
@@ -3,5 +3,24 @@
     "type": "system",
     "premium": false
   },
-  "includes": ["fonts/", "icons/", "json/", "LICENSE.txt", "README.md", "dnd5e-compiled.mjs.map", "templates/", "tokens/", "ui/"]
+  "includes": [
+    "fonts/",
+    "icons/",
+    "json/",
+    "LICENSE.txt",
+    "README.md",
+    "dnd5e-compiled.mjs.map",
+    "templates/",
+    "tokens/",
+    "ui/"
+  ],
+  "id": "wands",
+  "title": "Wizards & Shadows",
+  "version": "0.1.0",
+  "description": "Wizards & Shadows brings brooding arcana and political intrigue to Foundry Virtual Tabletop.",
+  "url": "https://github.com/wizards-and-shadows/wands",
+  "manifest": "https://raw.githubusercontent.com/wizards-and-shadows/wands/main/system.json",
+  "download": "https://github.com/wizards-and-shadows/wands/releases/download/v0.1.0/wands-0.1.0.zip",
+  "readme": "https://github.com/wizards-and-shadows/wands#readme",
+  "bugs": "https://github.com/wizards-and-shadows/wands/issues"
 }

--- a/system.json
+++ b/system.json
@@ -1,24 +1,24 @@
 {
-  "id": "dnd5e",
-  "title": "Dungeons & Dragons Fifth Edition",
-  "description": "A system for playing the fifth edition of the world's most popular role-playing game in the Foundry Virtual Tabletop environment.",
-  "version": "5.2.0",
+  "id": "wands",
+  "title": "Wizards & Shadows",
+  "description": "A dark fantasy toolkit for weaving tales of arcane intrigue and shifting alliances in Foundry Virtual Tabletop.",
+  "version": "0.1.0",
   "compatibility": {
     "minimum": "13.347",
     "verified": "13"
   },
-  "url": "https://github.com/foundryvtt/dnd5e/",
-  "manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json",
-  "download": "https://github.com/foundryvtt/dnd5e/releases/download/release-5.2.0/dnd5e-release-5.2.0.zip",
+  "url": "https://github.com/wizards-and-shadows/wands",
+  "manifest": "https://raw.githubusercontent.com/wizards-and-shadows/wands/main/system.json",
+  "download": "https://github.com/wizards-and-shadows/wands/releases/download/v0.1.0/wands-0.1.0.zip",
   "authors": [
     {
-      "name": "Atropos",
-      "url": "https://foundryvtt.com",
+      "name": "Wizards & Shadows Team",
+      "url": "https://github.com/wizards-and-shadows/wands",
       "flags": {}
     }
   ],
   "esmodules": [
-    "dnd5e.mjs"
+    "wands.mjs"
   ],
   "styles": [
     "dnd5e.css"
@@ -29,19 +29,35 @@
     },
     "Actor": {
       "character": {
-        "htmlFields": ["details.biography.value", "details.biography.public", "bastion.description"]
+        "htmlFields": [
+          "details.biography.value",
+          "details.biography.public",
+          "bastion.description"
+        ]
       },
       "encounter": {
-        "htmlFields": ["description.full", "description.summary"]
+        "htmlFields": [
+          "description.full",
+          "description.summary"
+        ]
       },
       "group": {
-        "htmlFields": ["description.full", "description.summary"]
+        "htmlFields": [
+          "description.full",
+          "description.summary"
+        ]
       },
       "npc": {
-        "htmlFields": ["details.biography.value", "details.biography.public"]
+        "htmlFields": [
+          "details.biography.value",
+          "details.biography.public"
+        ]
       },
       "vehicle": {
-        "htmlFields": ["details.biography.value", "details.biography.public"]
+        "htmlFields": [
+          "details.biography.value",
+          "details.biography.public"
+        ]
       }
     },
     "ChatMessage": {
@@ -52,79 +68,152 @@
     "Item": {
       "weapon": {
         "filePathFields": {
-          "activities.*.img": ["IMAGE"]
+          "activities.*.img": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "description.value",
+          "description.chat",
+          "unidentified.description"
+        ]
       },
       "equipment": {
         "filePathFields": {
-          "activities.*.img": ["IMAGE"]
+          "activities.*.img": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "description.value",
+          "description.chat",
+          "unidentified.description"
+        ]
       },
       "consumable": {
         "filePathFields": {
-          "activities.*.img": ["IMAGE"]
+          "activities.*.img": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "description.value",
+          "description.chat",
+          "unidentified.description"
+        ]
       },
       "tool": {
         "filePathFields": {
-          "activities.*.img": ["IMAGE"]
+          "activities.*.img": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "description.value",
+          "description.chat",
+          "unidentified.description"
+        ]
       },
       "loot": {
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "description.value",
+          "description.chat",
+          "unidentified.description"
+        ]
       },
       "race": {
         "filePathFields": {
-          "advancement.*.icon": ["IMAGE"]
+          "advancement.*.icon": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": [
+          "description.value",
+          "description.chat"
+        ]
       },
       "background": {
         "filePathFields": {
-          "advancement.*.icon": ["IMAGE"]
+          "advancement.*.icon": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": [
+          "description.value",
+          "description.chat"
+        ]
       },
       "class": {
         "filePathFields": {
-          "advancement.*.icon": ["IMAGE"]
+          "advancement.*.icon": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": [
+          "description.value",
+          "description.chat"
+        ]
       },
       "subclass": {
         "filePathFields": {
-          "advancement.*.icon": ["IMAGE"]
+          "advancement.*.icon": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": [
+          "description.value",
+          "description.chat"
+        ]
       },
       "spell": {
         "filePathFields": {
-          "activities.*.img": ["IMAGE"]
+          "activities.*.img": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": [
+          "description.value",
+          "description.chat"
+        ]
       },
       "feat": {
         "filePathFields": {
-          "activities.*.img": ["IMAGE"],
-          "advancement.*.icon": ["IMAGE"]
+          "activities.*.img": [
+            "IMAGE"
+          ],
+          "advancement.*.icon": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": [
+          "description.value",
+          "description.chat"
+        ]
       },
       "container": {
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "description.value",
+          "description.chat",
+          "unidentified.description"
+        ]
       },
       "backpack": {
-        "htmlFields": ["description.value", "description.chat", "unidentified.description"]
+        "htmlFields": [
+          "description.value",
+          "description.chat",
+          "unidentified.description"
+        ]
       },
       "facility": {
         "filePathFields": {
-          "activities.*.img": ["IMAGE"]
+          "activities.*.img": [
+            "IMAGE"
+          ]
         },
-        "htmlFields": ["description.value", "description.chat"]
+        "htmlFields": [
+          "description.value",
+          "description.chat"
+        ]
       }
     },
     "JournalEntryPage": {
@@ -139,337 +228,396 @@
       },
       "map": {},
       "rule": {
-        "htmlFields": ["tooltip"]
+        "htmlFields": [
+          "tooltip"
+        ]
       },
       "spells": {},
       "subclass": {
-        "htmlFields": ["details.value"]
+        "htmlFields": [
+          "details.value"
+        ]
       }
     },
     "RegionBehavior": {
-      "dnd5e.difficultTerrain": {},
-      "dnd5e.rotateArea": {}
+      "wands.difficultTerrain": {},
+      "wands.rotateArea": {}
     }
   },
   "packs": [
     {
-      "name": "heroes",
+      "name": "wands-heroes",
       "label": "Starter Heroes",
-      "system": "dnd5e",
-      "path": "packs/heroes",
+      "system": "wands",
+      "path": "packs/wands-heroes",
       "type": "Actor",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["character"]
+          "types": [
+            "character"
+          ]
         }
       }
     },
     {
-      "name": "monsters",
+      "name": "wands-monsters",
       "label": "Monsters (SRD)",
-      "system": "dnd5e",
-      "path": "packs/monsters",
+      "system": "wands",
+      "path": "packs/wands-monsters",
       "type": "Actor",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["npc"]
+          "types": [
+            "npc"
+          ]
         }
       }
     },
     {
-      "name": "items",
+      "name": "wands-items",
       "label": "Items (SRD)",
-      "system": "dnd5e",
-      "path": "packs/items",
+      "system": "wands",
+      "path": "packs/wands-items",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["weapon", "equipment", "consumable", "tool", "loot", "feat", "container"]
+          "types": [
+            "weapon",
+            "equipment",
+            "consumable",
+            "tool",
+            "loot",
+            "feat",
+            "container"
+          ]
         }
       }
     },
     {
-      "name": "tradegoods",
+      "name": "wands-tradegoods",
       "label": "Trade Goods (SRD)",
-      "system": "dnd5e",
-      "path": "packs/tradegoods",
+      "system": "wands",
+      "path": "packs/wands-tradegoods",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["loot"]
+          "types": [
+            "loot"
+          ]
         }
       }
     },
     {
-      "name": "spells",
+      "name": "wands-spells",
       "label": "Spells (SRD)",
-      "system": "dnd5e",
-      "path": "packs/spells",
+      "system": "wands",
+      "path": "packs/wands-spells",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sorting": "m",
           "sourceBook": "SRD 5.1",
-          "types": ["spell"]
+          "types": [
+            "spell"
+          ]
         }
       }
     },
     {
-      "name": "backgrounds",
+      "name": "wands-backgrounds",
       "label": "Backgrounds (SRD)",
-      "system": "dnd5e",
-      "path": "packs/backgrounds",
+      "system": "wands",
+      "path": "packs/wands-backgrounds",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["background", "feat"]
+          "types": [
+            "background",
+            "feat"
+          ]
         }
       }
     },
     {
-      "name": "classes",
+      "name": "wands-classes",
       "label": "Classes (SRD)",
-      "system": "dnd5e",
-      "path": "packs/classes",
+      "system": "wands",
+      "path": "packs/wands-classes",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["class"]
+          "types": [
+            "class"
+          ]
         }
       }
     },
     {
-      "name": "subclasses",
+      "name": "wands-subclasses",
       "label": "Subclasses (SRD)",
-      "system": "dnd5e",
-      "path": "packs/subclasses",
+      "system": "wands",
+      "path": "packs/wands-subclasses",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["subclass"]
+          "types": [
+            "subclass"
+          ]
         }
       }
     },
     {
-      "name": "classfeatures",
+      "name": "wands-classfeatures",
       "label": "Class & Subclass Features (SRD)",
-      "system": "dnd5e",
-      "path": "packs/classfeatures",
+      "system": "wands",
+      "path": "packs/wands-classfeatures",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["feat", "weapon"]
+          "types": [
+            "feat",
+            "weapon"
+          ]
         }
       }
     },
     {
-      "name": "races",
+      "name": "wands-races",
       "label": "Races (SRD)",
-      "system": "dnd5e",
-      "path": "packs/races",
+      "system": "wands",
+      "path": "packs/wands-races",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["race", "feat"]
+          "types": [
+            "race",
+            "feat"
+          ]
         }
       }
     },
     {
-      "name": "monsterfeatures",
+      "name": "wands-monsterfeatures",
       "label": "Monster Features (SRD)",
-      "system": "dnd5e",
-      "path": "packs/monsterfeatures",
+      "system": "wands",
+      "path": "packs/wands-monsterfeatures",
       "type": "Item",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.1",
-          "types": ["feat", "weapon"]
+          "types": [
+            "feat",
+            "weapon"
+          ]
         }
       }
     },
     {
-      "name": "rules",
+      "name": "wands-rules",
       "label": "Rules (SRD)",
-      "system": "dnd5e",
-      "path": "packs/rules",
+      "system": "wands",
+      "path": "packs/wands-rules",
       "type": "JournalEntry",
       "private": false,
       "flags": {
-        "dnd5e": {
+        "wands": {
           "display": "table-of-contents"
         }
       }
     },
     {
-      "name": "tables",
+      "name": "wands-tables",
       "label": "Tables (SRD)",
-      "system": "dnd5e",
-      "path": "packs/tables",
+      "system": "wands",
+      "path": "packs/wands-tables",
       "type": "RollTable",
       "private": false,
       "flags": {}
     },
     {
-      "name": "content24",
+      "name": "wands-content24",
       "label": "Rules",
-      "path": "packs/content24",
+      "path": "packs/wands-content24",
       "type": "JournalEntry",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e",
+      "system": "wands",
       "flags": {
         "display": "table-of-contents"
       }
     },
     {
-      "name": "classes24",
+      "name": "wands-classes24",
       "label": "Character Classes",
-      "path": "packs/classes24",
+      "path": "packs/wands-classes24",
       "type": "Item",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e",
+      "system": "wands",
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.2",
-          "types": ["class", "subclass", "feat"]
+          "types": [
+            "class",
+            "subclass",
+            "feat"
+          ]
         }
       }
     },
     {
-      "name": "origins24",
+      "name": "wands-origins24",
       "label": "Character Origins",
-      "path": "packs/origins24",
+      "path": "packs/wands-origins24",
       "type": "Item",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e",
+      "system": "wands",
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.2",
-          "types": ["race", "background", "feat"]
+          "types": [
+            "race",
+            "background",
+            "feat"
+          ]
         }
       }
     },
     {
-      "name": "feats24",
+      "name": "wands-feats24",
       "label": "Feats",
-      "path": "packs/feats24",
+      "path": "packs/wands-feats24",
       "type": "Item",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e",
+      "system": "wands",
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.2",
-          "types": ["feat"]
+          "types": [
+            "feat"
+          ]
         }
       }
     },
     {
-      "name": "spells24",
+      "name": "wands-spells24",
       "label": "Spells",
-      "path": "packs/spells24",
+      "path": "packs/wands-spells24",
       "type": "Item",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e",
+      "system": "wands",
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sorting": "m",
           "sourceBook": "SRD 5.2",
-          "types": ["spell"]
+          "types": [
+            "spell"
+          ]
         }
       }
     },
     {
-      "name": "equipment24",
+      "name": "wands-equipment24",
       "label": "Equipment",
-      "path": "packs/equipment24",
+      "path": "packs/wands-equipment24",
       "type": "Item",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e",
+      "system": "wands",
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.2",
-          "types": ["weapon", "equipment", "consumable", "tool", "loot", "feat", "container"]
+          "types": [
+            "weapon",
+            "equipment",
+            "consumable",
+            "tool",
+            "loot",
+            "feat",
+            "container"
+          ]
         }
       }
     },
     {
-      "name": "tables24",
+      "name": "wands-tables24",
       "label": "Roll Tables",
-      "path": "packs/tables24",
+      "path": "packs/wands-tables24",
       "type": "RollTable",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e"
+      "system": "wands"
     },
     {
-      "name": "actors24",
+      "name": "wands-actors24",
       "label": "Actors",
-      "path": "packs/actors24",
+      "path": "packs/wands-actors24",
       "type": "Actor",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e",
+      "system": "wands",
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sorting": "m",
           "sourceBook": "SRD 5.2"
         }
       }
     },
     {
-      "name": "monsterfeatures24",
+      "name": "wands-monsterfeatures24",
       "label": "Monster Features",
-      "path": "packs/monsterfeatures24",
+      "path": "packs/wands-monsterfeatures24",
       "type": "Item",
       "ownership": {
         "ASSISTANT": "OWNER"
       },
-      "system": "dnd5e",
+      "system": "wands",
       "flags": {
-        "dnd5e": {
+        "wands": {
           "sourceBook": "SRD 5.2",
-          "types": ["feat", "weapon"]
+          "types": [
+            "feat",
+            "weapon"
+          ]
         }
       }
     }
@@ -480,15 +628,15 @@
       "color": "#cd2c1e",
       "sorting": "m",
       "packs": [
-        "content24",
-        "classes24",
-        "origins24",
-        "feats24",
-        "spells24",
-        "tables24",
-        "actors24",
-        "equipment24",
-        "monsterfeatures24"
+        "wands-content24",
+        "wands-classes24",
+        "wands-origins24",
+        "wands-feats24",
+        "wands-spells24",
+        "wands-tables24",
+        "wands-actors24",
+        "wands-equipment24",
+        "wands-monsterfeatures24"
       ]
     },
     {
@@ -496,9 +644,9 @@
       "sorting": "m",
       "color": "#cd2c1e",
       "packs": [
-        "rules",
-        "tables",
-        "heroes"
+        "wands-rules",
+        "wands-tables",
+        "wands-heroes"
       ],
       "folders": [
         {
@@ -506,11 +654,11 @@
           "sorting": "m",
           "color": "#b72c1f",
           "packs": [
-            "classes",
-            "subclasses",
-            "classfeatures",
-            "backgrounds",
-            "races"
+            "wands-classes",
+            "wands-subclasses",
+            "wands-classfeatures",
+            "wands-backgrounds",
+            "wands-races"
           ]
         },
         {
@@ -518,9 +666,9 @@
           "sorting": "m",
           "color": "#941919 ",
           "packs": [
-            "items",
-            "spells",
-            "tradegoods"
+            "wands-items",
+            "wands-spells",
+            "wands-tradegoods"
           ]
         },
         {
@@ -528,8 +676,8 @@
           "sorting": "m",
           "color": "#7d160c",
           "packs": [
-            "monsters",
-            "monsterfeatures"
+            "wands-monsters",
+            "wands-monsterfeatures"
           ]
         }
       ]
@@ -551,8 +699,8 @@
     },
     {
       "type": "setup",
-      "url": "systems/dnd5e/ui/official/dnd5e-repo.jpg",
-      "thumbnail": "systems/dnd5e/ui/official/dnd5e-thumbnail.jpg"
+      "url": "systems/wands/ui/official/dnd5e-repo.jpg",
+      "thumbnail": "systems/wands/ui/official/dnd5e-thumbnail.jpg"
     }
   ],
   "socket": true,
@@ -561,15 +709,15 @@
     "units": "ft"
   },
   "primaryTokenAttribute": "attributes.hp",
-  "background": "systems/dnd5e/ui/official/dnd5e-background.webp",
+  "background": "systems/wands/ui/official/dnd5e-background.webp",
   "flags": {
     "compendiumArtMappings": {
-      "dnd5e": {
-        "mapping": "systems/dnd5e/json/fa-token-mapping.json",
+      "wands": {
+        "mapping": "systems/wands/json/fa-token-mapping.json",
         "credit": "<em>Token artwork by <a href=\"https://www.forgotten-adventures.net/\" target=\"_blank\" rel=\"noopener\">Forgotten Adventures</a>.</em>"
       }
     },
-    "dnd5e": {
+    "wands": {
       "sourceBooks": {
         "SRD 5.1": "SOURCE.BOOK.SRD51",
         "SRD 5.2": "SOURCE.BOOK.SRD52"
@@ -578,8 +726,16 @@
     "needsMigrationVersion": "5.1.0",
     "compatibleMigrationVersion": "0.8",
     "hotReload": {
-      "extensions": ["css", "hbs", "json"],
-      "paths": ["dnd5e.css", "templates", "lang"]
+      "extensions": [
+        "css",
+        "hbs",
+        "json"
+      ],
+      "paths": [
+        "dnd5e.css",
+        "templates",
+        "lang"
+      ]
     }
   }
 }

--- a/wands.mjs
+++ b/wands.mjs
@@ -1,0 +1,679 @@
+/**
+ * The Wizards & Shadows game system for Foundry Virtual Tabletop
+ * A dark fantasy ruleset of clandestine cabals, arcane intrigue, and shifting loyalties.
+ * Author: Wizards & Shadows Team
+ * Software License: MIT
+ * Repository: https://github.com/wizards-and-shadows/wands
+ * Issue Tracker: https://github.com/wizards-and-shadows/wands/issues
+ */
+
+// Import Configuration
+import DND5E from "./module/config.mjs";
+import {
+  applyLegacyRules, registerDeferredSettings, registerSystemKeybindings, registerSystemSettings
+} from "./module/settings.mjs";
+
+// Import Submodules
+import * as applications from "./module/applications/_module.mjs";
+import * as canvas from "./module/canvas/_module.mjs";
+import * as dataModels from "./module/data/_module.mjs";
+import * as dice from "./module/dice/_module.mjs";
+import * as documents from "./module/documents/_module.mjs";
+import * as enrichers from "./module/enrichers.mjs";
+import * as Filter from "./module/filter.mjs";
+import * as migrations from "./module/migration.mjs";
+import ModuleArt from "./module/module-art.mjs";
+import { registerModuleData, setupModulePacks } from "./module/module-registration.mjs";
+import { default as registry } from "./module/registry.mjs";
+import Tooltips5e from "./module/tooltips.mjs";
+import * as utils from "./module/utils.mjs";
+import DragDrop5e from "./module/drag-drop.mjs";
+
+/* -------------------------------------------- */
+/*  Define Module Structure                     */
+/* -------------------------------------------- */
+
+const SYSTEM_NAMESPACE = {
+  applications,
+  canvas,
+  config: DND5E,
+  dataModels,
+  dice,
+  documents,
+  enrichers,
+  Filter,
+  migrations,
+  registry,
+  utils
+};
+
+globalThis.wands = SYSTEM_NAMESPACE;
+globalThis.dnd5e = SYSTEM_NAMESPACE;
+
+/* -------------------------------------------- */
+/*  Foundry VTT Initialization                  */
+/* -------------------------------------------- */
+
+Hooks.once("init", function() {
+  const namespace = Object.assign(game.system, globalThis.wands);
+  globalThis.wands = game.wands = namespace;
+  globalThis.dnd5e = game.dnd5e = namespace;
+  utils.log(`Initializing the Wizards & Shadows Game System - Version ${namespace.version}\n${DND5E.ASCII}`);
+
+  // Record Configuration Values
+  CONFIG.WANDS = DND5E;
+  CONFIG.DND5E = CONFIG.WANDS;
+  CONFIG.ActiveEffect.documentClass = documents.ActiveEffect5e;
+  CONFIG.ActiveEffect.legacyTransferral = false;
+  CONFIG.Actor.collection = dataModels.collection.Actors5e;
+  CONFIG.Actor.documentClass = documents.Actor5e;
+  CONFIG.Adventure.documentClass = documents.Adventure5e;
+  CONFIG.Canvas.layers.tokens.layerClass = CONFIG.Token.layerClass = canvas.layers.TokenLayer5e;
+  CONFIG.ChatMessage.documentClass = documents.ChatMessage5e;
+  CONFIG.Combat.documentClass = documents.Combat5e;
+  CONFIG.Combatant.documentClass = documents.Combatant5e;
+  CONFIG.CombatantGroup.documentClass = documents.CombatantGroup5e;
+  CONFIG.Item.collection = dataModels.collection.Items5e;
+  CONFIG.Item.compendiumIndexFields.push("system.container", "system.identifier");
+  CONFIG.Item.documentClass = documents.Item5e;
+  CONFIG.JournalEntryPage.documentClass = documents.JournalEntryPage5e;
+  CONFIG.Token.documentClass = documents.TokenDocument5e;
+  CONFIG.Token.objectClass = canvas.Token5e;
+  CONFIG.Token.rulerClass = canvas.TokenRuler5e;
+  CONFIG.Token.movement.TerrainData = dataModels.TerrainData5e;
+  CONFIG.User.documentClass = documents.User5e;
+  CONFIG.time.roundTime = 6;
+  Roll.TOOLTIP_TEMPLATE = "systems/wands/templates/chat/roll-breakdown.hbs";
+  CONFIG.Dice.BasicRoll = dice.BasicRoll;
+  CONFIG.Dice.DamageRoll = dice.DamageRoll;
+  CONFIG.Dice.D20Die = dice.D20Die;
+  CONFIG.Dice.D20Roll = dice.D20Roll;
+  CONFIG.MeasuredTemplate.defaults.angle = 53.13; // 5e cone RAW should be 53.13 degrees
+  CONFIG.Note.objectClass = canvas.Note5e;
+  CONFIG.ui.chat = applications.ChatLog5e;
+  CONFIG.ui.combat = applications.combat.CombatTracker5e;
+  CONFIG.ui.items = applications.item.ItemDirectory5e;
+  CONFIG.ux.DragDrop = DragDrop5e;
+
+  // Register System Settings
+  registerSystemSettings();
+  registerSystemKeybindings();
+
+  // Configure module art
+  namespace.moduleArt = new ModuleArt();
+
+  // Configure bastions
+  namespace.bastion = new documents.Bastion();
+
+  // Configure tooltips
+  namespace.tooltips = new Tooltips5e();
+
+  // Remove honor & sanity from configuration if they aren't enabled
+  if ( !game.settings.get("dnd5e", "honorScore") ) delete DND5E.abilities.hon;
+  if ( !game.settings.get("dnd5e", "sanityScore") ) delete DND5E.abilities.san;
+
+  // Legacy rules.
+  if ( game.settings.get("dnd5e", "rulesVersion") === "legacy" ) applyLegacyRules();
+
+  // Register system
+  DND5E.SPELL_LISTS.forEach(uuid => namespace.registry.spellLists.register(uuid));
+
+  // Register module data from manifests
+  registerModuleData();
+
+  // Register Roll Extensions
+  CONFIG.Dice.rolls = [dice.BasicRoll, dice.D20Roll, dice.DamageRoll];
+
+  // Hook up system data types
+  CONFIG.ActiveEffect.dataModels = dataModels.activeEffect.config;
+  CONFIG.Actor.dataModels = dataModels.actor.config;
+  CONFIG.ChatMessage.dataModels = dataModels.chatMessage.config;
+  CONFIG.Item.dataModels = dataModels.item.config;
+  CONFIG.JournalEntryPage.dataModels = dataModels.journal.config;
+  Object.assign(CONFIG.RegionBehavior.dataModels, dataModels.regionBehavior.config);
+  Object.assign(CONFIG.RegionBehavior.typeIcons, dataModels.regionBehavior.icons);
+
+  // Add fonts
+  _configureFonts();
+
+  // Register sheet application classes
+  const DocumentSheetConfig = foundry.applications.apps.DocumentSheetConfig;
+  DocumentSheetConfig.unregisterSheet(Actor, "core", foundry.appv1.sheets.ActorSheet);
+  DocumentSheetConfig.registerSheet(Actor, "wands", applications.actor.CharacterActorSheet, {
+    types: ["character"],
+    makeDefault: true,
+    label: "DND5E.SheetClass.Character"
+  });
+  DocumentSheetConfig.registerSheet(Actor, "wands", applications.actor.NPCActorSheet, {
+    types: ["npc"],
+    makeDefault: true,
+    label: "DND5E.SheetClass.NPC"
+  });
+  DocumentSheetConfig.registerSheet(Actor, "wands", applications.actor.ActorSheet5eVehicle, {
+    types: ["vehicle"],
+    makeDefault: true,
+    label: "DND5E.SheetClass.Vehicle"
+  });
+  DocumentSheetConfig.registerSheet(Actor, "wands", applications.actor.GroupActorSheet, {
+    types: ["group"],
+    makeDefault: true,
+    label: "DND5E.SheetClass.Group"
+  });
+  DocumentSheetConfig.registerSheet(Actor, "wands", applications.actor.EncounterActorSheet, {
+    types: ["encounter"],
+    makeDefault: true,
+    label: "DND5E.SheetClass.Encounter"
+  });
+
+  DocumentSheetConfig.unregisterSheet(Item, "core", foundry.appv1.sheets.ItemSheet);
+  DocumentSheetConfig.registerSheet(Item, "wands", applications.item.ItemSheet5e, {
+    makeDefault: true,
+    label: "DND5E.SheetClass.Item"
+  });
+  DocumentSheetConfig.unregisterSheet(Item, "wands", applications.item.ItemSheet5e, { types: ["container"] });
+  DocumentSheetConfig.registerSheet(Item, "wands", applications.item.ContainerSheet, {
+    makeDefault: true,
+    types: ["container"],
+    label: "DND5E.SheetClass.Container"
+  });
+
+  DocumentSheetConfig.registerSheet(JournalEntry, "wands", applications.journal.JournalEntrySheet5e, {
+    makeDefault: true,
+    label: "DND5E.SheetClass.JournalEntry"
+  });
+  DocumentSheetConfig.registerSheet(JournalEntry, "wands", applications.journal.JournalSheet5e, {
+    makeDefault: false,
+    canConfigure: false,
+    canBeDefault: false,
+    label: "DND5E.SheetClass.JournalEntrySheetLegacy"
+  });
+  DocumentSheetConfig.registerSheet(JournalEntryPage, "wands", applications.journal.JournalClassPageSheet, {
+    label: "DND5E.SheetClass.ClassSummary",
+    types: ["class", "subclass"]
+  });
+  DocumentSheetConfig.registerSheet(JournalEntryPage, "wands", applications.journal.JournalMapLocationPageSheet, {
+    label: "DND5E.SheetClass.MapLocation",
+    types: ["map"]
+  });
+  DocumentSheetConfig.registerSheet(JournalEntryPage, "wands", applications.journal.JournalRulePageSheet, {
+    label: "DND5E.SheetClass.Rule",
+    types: ["rule"]
+  });
+  DocumentSheetConfig.registerSheet(JournalEntryPage, "wands", applications.journal.JournalSpellListPageSheet, {
+    label: "DND5E.SheetClass.SpellList",
+    types: ["spells"]
+  });
+
+  DocumentSheetConfig.unregisterSheet(RegionBehavior, "core", foundry.applications.sheets.RegionBehaviorConfig, {
+    types: ["wands.difficultTerrain", "wands.rotateArea"]
+  });
+  DocumentSheetConfig.registerSheet(RegionBehavior, "wands", applications.regionBehavior.DifficultTerrainConfig, {
+    label: "DND5E.SheetClass.DifficultTerrain",
+    types: ["wands.difficultTerrain"]
+  });
+  DocumentSheetConfig.registerSheet(RegionBehavior, "wands", applications.regionBehavior.RotateAreaConfig, {
+    label: "DND5E.SheetClass.RotateArea",
+    types: ["wands.rotateArea"]
+  });
+
+  CONFIG.Token.prototypeSheetClass = applications.PrototypeTokenConfig5e;
+  DocumentSheetConfig.unregisterSheet(TokenDocument, "core", foundry.applications.sheets.TokenConfig);
+  DocumentSheetConfig.registerSheet(TokenDocument, "wands", applications.TokenConfig5e, {
+    label: "DND5E.SheetClass.Token"
+  });
+
+  // Preload Handlebars helpers & partials
+  utils.registerHandlebarsHelpers();
+  utils.preloadHandlebarsTemplates();
+
+  // Enrichers
+  enrichers.registerCustomEnrichers();
+
+  // Exhaustion handling
+  documents.ActiveEffect5e.registerHUDListeners();
+
+  // Set up token movement actions
+  documents.TokenDocument5e.registerMovementActions();
+
+  // Custom movement cost aggregator
+  CONFIG.Token.movement.costAggregator = (results, distance, segment) => {
+    return Math.max(...results.map(i => i.cost));
+  };
+});
+
+
+/* -------------------------------------------- */
+
+/**
+ * Configure explicit lists of attributes that are trackable on the token HUD and in the combat tracker.
+ * @internal
+ */
+function _configureTrackableAttributes() {
+  const common = {
+    bar: [],
+    value: [
+      ...Object.keys(DND5E.abilities).map(ability => `abilities.${ability}.value`),
+      ...Object.keys(DND5E.movementTypes).map(movement => `attributes.movement.${movement}`),
+      "attributes.ac.value", "attributes.init.total"
+    ]
+  };
+
+  const creature = {
+    bar: [
+      ...common.bar,
+      "attributes.hp",
+      ..._trackedSpellAttributes()
+    ],
+    value: [
+      ...common.value,
+      ...Object.keys(DND5E.skills).map(skill => `skills.${skill}.passive`),
+      ...Object.keys(DND5E.senses).map(sense => `attributes.senses.${sense}`),
+      "attributes.spell.attack", "attributes.spell.dc"
+    ]
+  };
+
+  CONFIG.Actor.trackableAttributes = {
+    character: {
+      bar: [...creature.bar, "resources.primary", "resources.secondary", "resources.tertiary", "details.xp"],
+      value: [...creature.value]
+    },
+    npc: {
+      bar: [...creature.bar, "resources.legact", "resources.legres"],
+      value: [...creature.value, "attributes.spell.level", "details.cr", "details.xp.value"]
+    },
+    vehicle: {
+      bar: [...common.bar, "attributes.hp"],
+      value: [...common.value]
+    },
+    group: {
+      bar: [],
+      value: []
+    }
+  };
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Get all trackable spell slot attributes.
+ * @returns {Set<string>}
+ * @internal
+ */
+function _trackedSpellAttributes() {
+  return Object.entries(DND5E.spellcasting).reduce((acc, [k, v]) => {
+    if ( v.slots ) Array.fromRange(Object.keys(DND5E.spellLevels).length - 1, 1).forEach(l => {
+      acc.add(`spells.${v.getSpellSlotKey(l)}`);
+    });
+    return acc;
+  }, new Set());
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Configure which attributes are available for item consumption.
+ * @internal
+ */
+function _configureConsumableAttributes() {
+  CONFIG.WANDS.consumableResources = [
+    ...Object.keys(DND5E.abilities).map(ability => `abilities.${ability}.value`),
+    "attributes.ac.flat",
+    "attributes.hp.value",
+    "attributes.exhaustion",
+    ...Object.keys(DND5E.senses).map(sense => `attributes.senses.${sense}`),
+    ...Object.keys(DND5E.movementTypes).map(type => `attributes.movement.${type}`),
+    ...Object.keys(DND5E.currencies).map(denom => `currency.${denom}`),
+    "details.xp.value",
+    "resources.primary.value", "resources.secondary.value", "resources.tertiary.value",
+    "resources.legact.value", "resources.legres.value",
+    ..._trackedSpellAttributes()
+  ];
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Configure additional system fonts.
+ */
+function _configureFonts() {
+  Object.assign(CONFIG.fontDefinitions, {
+    Roboto: {
+      editor: true,
+      fonts: [
+        { urls: ["systems/wands/fonts/roboto/Roboto-Regular.woff2"] },
+        { urls: ["systems/wands/fonts/roboto/Roboto-Bold.woff2"], weight: "bold" },
+        { urls: ["systems/wands/fonts/roboto/Roboto-Italic.woff2"], style: "italic" },
+        { urls: ["systems/wands/fonts/roboto/Roboto-BoldItalic.woff2"], weight: "bold", style: "italic" }
+      ]
+    },
+    "Roboto Condensed": {
+      editor: true,
+      fonts: [
+        { urls: ["systems/wands/fonts/roboto-condensed/RobotoCondensed-Regular.woff2"] },
+        { urls: ["systems/wands/fonts/roboto-condensed/RobotoCondensed-Bold.woff2"], weight: "bold" },
+        { urls: ["systems/wands/fonts/roboto-condensed/RobotoCondensed-Italic.woff2"], style: "italic" },
+        {
+          urls: ["systems/wands/fonts/roboto-condensed/RobotoCondensed-BoldItalic.woff2"], weight: "bold",
+          style: "italic"
+        }
+      ]
+    },
+    "Roboto Slab": {
+      editor: true,
+      fonts: [
+        { urls: ["systems/wands/fonts/roboto-slab/RobotoSlab-Regular.ttf"] },
+        { urls: ["systems/wands/fonts/roboto-slab/RobotoSlab-Bold.ttf"], weight: "bold" }
+      ]
+    }
+  });
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Configure system status effects.
+ */
+function _configureStatusEffects() {
+  const addEffect = (effects, {special, ...data}) => {
+    data = foundry.utils.deepClone(data);
+    data._id = utils.staticID(`dnd5e${data.id}`);
+    if ( data.icon ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `icon` property of status conditions has been deprecated in place of using `img`.",
+        { since: "DnD5e 5.0", until: "DnD5e 5.2" }
+      );
+      data.img = data.icon;
+      delete data.icon;
+    }
+    if ( data.label ) {
+      foundry.utils.logCompatibilityWarning(
+        "The `label` property of status conditions has been deprecated in place of using `name`.",
+        { since: "DnD5e 5.0", until: "DnD5e 5.2" }
+      );
+      data.name = data.label;
+      delete data.label;
+    }
+    effects.push(data);
+    if ( special ) CONFIG.specialStatusEffects[special] = data.id;
+    if ( data.neverBlockMovement ) DND5E.neverBlockStatuses.add(data.id);
+  };
+  CONFIG.statusEffects = Object.entries(CONFIG.WANDS.statusEffects).reduce((arr, [id, data]) => {
+    const original = CONFIG.statusEffects.find(s => s.id === id);
+    addEffect(arr, foundry.utils.mergeObject(original ?? {}, { id, ...data }, { inplace: false }));
+    return arr;
+  }, []);
+  for ( const [id, data] of Object.entries(CONFIG.WANDS.conditionTypes) ) {
+    addEffect(CONFIG.statusEffects, { id, ...data });
+  }
+  for ( const [id, data] of Object.entries(CONFIG.WANDS.encumbrance.effects) ) {
+    addEffect(CONFIG.statusEffects, { id, ...data, hud: false });
+  }
+}
+
+/* -------------------------------------------- */
+/*  Foundry VTT Setup                           */
+/* -------------------------------------------- */
+
+/**
+ * Prepare attribute lists.
+ */
+Hooks.once("setup", function() {
+  // Configure trackable & consumable attributes.
+  _configureTrackableAttributes();
+  _configureConsumableAttributes();
+
+  CONFIG.WANDS.trackableAttributes = expandAttributeList(CONFIG.WANDS.trackableAttributes);
+  game.wands.moduleArt.registerModuleArt();
+  Tooltips5e.activateListeners();
+  game.wands.tooltips.observe();
+
+  // Register settings after modules have had a chance to initialize
+  registerDeferredSettings();
+
+  // Set up compendiums with custom applications & sorting
+  setupModulePacks();
+
+  // Create CSS for currencies
+  const style = document.createElement("style");
+  const currencies = append => Object.entries(CONFIG.WANDS.currencies)
+    .map(([key, { icon }]) => `&.${key}${append ?? ""} { background-image: url("${icon}"); }`);
+  style.innerHTML = `
+    :is(.dnd5e2, .dnd5e2-journal) :is(i, span).currency {
+      ${currencies().join("\n")}
+    }
+    .dnd5e2 .form-group label.label-icon.currency {
+      ${currencies("::after").join("\n")}
+    }
+  `;
+  document.head.append(style);
+
+  _migrateInventoryMetadata();
+});
+
+/* --------------------------------------------- */
+
+/**
+ * Expand a list of attribute paths into an object that can be traversed.
+ * @param {string[]} attributes  The initial attributes configuration.
+ * @returns {object}  The expanded object structure.
+ */
+function expandAttributeList(attributes) {
+  return attributes.reduce((obj, attr) => {
+    foundry.utils.setProperty(obj, attr, true);
+    return obj;
+  }, {});
+}
+
+/* --------------------------------------------- */
+
+/**
+ * Perform one-time pre-localization and sorting of some configuration objects
+ */
+Hooks.once("i18nInit", () => {
+  // Set up status effects. Explicitly performed after init and before prelocalization.
+  _configureStatusEffects();
+
+  if ( game.settings.get("dnd5e", "rulesVersion") === "legacy" ) {
+    const { translations, _fallback } = game.i18n;
+    foundry.utils.mergeObject(translations, {
+      "TYPES.Item": {
+        race: game.i18n.localize("TYPES.Item.raceLegacy"),
+        racePl: game.i18n.localize("TYPES.Item.raceLegacyPl")
+      },
+      DND5E: {
+        "Feature.Species": game.i18n.localize("DND5E.Feature.SpeciesLegacy"),
+        FlagsAlertHint: game.i18n.localize("DND5E.FlagsAlertHintLegacy"),
+        ItemSpeciesDetails: game.i18n.localize("DND5E.ItemSpeciesDetailsLegacy"),
+        "Language.Category.Rare": game.i18n.localize("DND5E.Language.Category.Exotic"),
+        RacialTraits: game.i18n.localize("DND5E.RacialTraitsLegacy"),
+        "REST.Long.Hint.Normal": game.i18n.localize("DND5E.REST.Long.Hint.NormalLegacy"),
+        "REST.Long.Hint.Group": game.i18n.localize("DND5E.REST.Long.Hint.GroupLegacy"),
+        "Species.Add": game.i18n.localize("DND5E.Species.AddLegacy"),
+        "Species.Features": game.i18n.localize("DND5E.Species.FeaturesLegacy"),
+        "TARGET.Type.Emanation": foundry.utils.mergeObject(
+          _fallback.DND5E?.TARGET?.Type?.Radius ?? {},
+          translations.DND5E?.TARGET?.Type?.Radius ?? {},
+          { inplace: false }
+        ),
+        TraitArmorPlural: foundry.utils.mergeObject(
+          _fallback.DND5E?.TraitArmorLegacyPlural ?? {},
+          translations.DND5E?.TraitArmorLegacyPlural ?? {},
+          { inplace: false }
+        ),
+        TraitArmorProf: game.i18n.localize("DND5E.TraitArmorLegacyProf")
+      }
+    });
+  }
+  utils.performPreLocalization(CONFIG.WANDS);
+  Object.values(CONFIG.WANDS.activityTypes).forEach(c => c.documentClass.localize());
+  Object.values(CONFIG.WANDS.advancementTypes).forEach(c => c.documentClass.localize());
+  foundry.helpers.Localization.localizeDataModel(dataModels.settings.TransformationSetting);
+
+  // Spellcasting
+  dataModels.spellcasting.SpellcastingModel.fromConfig();
+});
+
+/* -------------------------------------------- */
+/*  Foundry VTT Ready                           */
+/* -------------------------------------------- */
+
+/**
+ * Once the entire VTT framework is initialized, check to see if we should perform a data migration
+ */
+Hooks.once("ready", function() {
+  // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
+  Hooks.on("hotbarDrop", (bar, data, slot) => {
+    if ( ["ActiveEffect", "Activity", "Item"].includes(data.type) ) {
+      documents.macro.create5eMacro(data, slot);
+      return false;
+    }
+  });
+
+  // Adjust sourced items on actors now that compendium UUID redirects have been initialized
+  game.actors.forEach(a => a.sourcedItems._redirectKeys());
+
+  // Register items by type
+  dnd5e.registry.classes.initialize();
+  dnd5e.registry.subclasses.initialize();
+
+  // Chat message listeners
+  documents.ChatMessage5e.activateListeners();
+
+  // Bastion initialization
+  game.wands.bastion.initializeUI();
+
+  // Determine whether a system migration is required and feasible
+  if ( !game.user.isGM ) return;
+  const cv = game.settings.get("dnd5e", "systemMigrationVersion") || game.world.flags.dnd5e?.version;
+  const totalDocuments = game.actors.size + game.scenes.size + game.items.size;
+  if ( !cv && totalDocuments === 0 ) return game.settings.set("dnd5e", "systemMigrationVersion", game.system.version);
+  if ( cv && !foundry.utils.isNewerVersion(game.system.flags.needsMigrationVersion, cv) ) return;
+
+  // Compendium pack folder migration.
+  if ( foundry.utils.isNewerVersion("3.0.0", cv) ) {
+    migrations.reparentCompendiums("DnD5e SRD Content", "D&D SRD Content");
+  }
+
+  // Perform the migration
+  if ( cv && foundry.utils.isNewerVersion(game.system.flags.compatibleMigrationVersion, cv) ) {
+    ui.notifications.error("MIGRATION.5eVersionTooOldWarning", {localize: true, permanent: true});
+  }
+  migrations.migrateWorld();
+});
+
+/* -------------------------------------------- */
+/*  System Styling                              */
+/* -------------------------------------------- */
+
+Hooks.on("renderGamePause", (app, html) => {
+  if ( Hooks.events.renderGamePause.length > 1 ) return;
+  html.classList.add("dnd5e2");
+  const container = document.createElement("div");
+  container.classList.add("flexcol");
+  container.append(...html.children);
+  html.append(container);
+  const img = html.querySelector("img");
+  img.src = "systems/wands/ui/official/ampersand.svg";
+  img.className = "";
+});
+
+Hooks.on("renderSettings", (app, html) => applications.settings.sidebar.renderSettings(html));
+
+/* -------------------------------------------- */
+/*  Other Hooks                                 */
+/* -------------------------------------------- */
+
+Hooks.on("applyCompendiumArt", (documentClass, ...args) => documentClass.applyCompendiumArt?.(...args));
+
+Hooks.on("renderChatPopout", documents.ChatMessage5e.onRenderChatPopout);
+Hooks.on("getChatMessageContextOptions", documents.ChatMessage5e.addChatMessageContextOptions);
+
+Hooks.on("renderChatLog", (app, html, data) => {
+  documents.Item5e.chatListeners(html);
+  documents.ChatMessage5e.onRenderChatLog(html);
+});
+Hooks.on("renderChatPopout", (app, html, data) => documents.Item5e.chatListeners(html));
+
+Hooks.on("chatMessage", (app, message, data) => applications.Award.chatMessage(message));
+Hooks.on("createChatMessage", dataModels.chatMessage.RequestMessageData.onCreateMessage);
+Hooks.on("updateChatMessage", dataModels.chatMessage.RequestMessageData.onUpdateResultMessage);
+
+Hooks.on("renderActorDirectory", (app, html, data) => documents.Actor5e.onRenderActorDirectory(html));
+
+Hooks.on("getActorContextOptions", documents.Actor5e.addDirectoryContextOptions);
+Hooks.on("getItemContextOptions", documents.Item5e.addDirectoryContextOptions);
+
+Hooks.on("renderCompendiumDirectory", (app, html) => applications.CompendiumBrowser.injectSidebarButton(html));
+
+Hooks.on("renderJournalEntryPageSheet", applications.journal.JournalEntrySheet5e.onRenderJournalPageSheet);
+
+Hooks.on("renderActiveEffectConfig", documents.ActiveEffect5e.onRenderActiveEffectConfig);
+
+Hooks.on("renderDocumentSheetConfig", (app, html) => {
+  const { document } = app.options;
+  if ( (document instanceof Actor) && document.system.isGroup ) {
+    applications.actor.MultiActorSheet.addDocumentSheetConfigOptions(app, html);
+  }
+});
+
+Hooks.on("targetToken", canvas.Token5e.onTargetToken);
+
+Hooks.on("renderCombatTracker", (app, html, data) => app.renderGroups(html));
+
+Hooks.on("preCreateScene", (doc, createData, options, userId) => {
+  // Set default grid units based on metric length setting
+  const units = utils.defaultUnits("length");
+  if ( (units !== dnd5e.grid.units) && !foundry.utils.getProperty(createData, "grid.distance")
+    && !foundry.utils.getProperty(createData, "grid.units") ) {
+    doc.updateSource({
+      grid: { distance: utils.convertLength(dnd5e.grid.distance, dnd5e.grid.units, units, { strict: false }), units }
+    });
+  }
+});
+
+/* -------------------------------------------- */
+/*  Deprecations                                */
+/* -------------------------------------------- */
+
+/**
+ * Migrate legacy inventory metadata.
+ */
+function _migrateInventoryMetadata() {
+  Object.entries(CONFIG.Item.dataModels).forEach(([type, model]) => {
+    if ( ("inventorySection" in model) || (model.metadata.inventoryItem === false) ) return;
+    if ( !("inventoryItem" in model.metadata) && !("inventoryOrder" in model.metadata) ) return;
+    const { inventoryOrder=Infinity } = model.metadata;
+    foundry.utils.logCompatibilityWarning("ItemDataModel.metadata.inventoryItem and "
+      + "ItemDataModel.metadata.inventoryOrder are deprecated. Please define an inventorySection getter on the model "
+      + "instead.", { since: "dnd5e 5.0", until: "dnd5e 5.2" });
+    Object.defineProperty(model, "inventorySection", {
+      get() {
+        return {
+          id: type,
+          order: inventoryOrder,
+          label: `${CONFIG.Item.typeLabels[type]}Pl`,
+          groups: { type },
+          columns: ["price", "weight", "quantity", "charges", "controls"]
+        };
+      }
+    });
+  });
+}
+
+/* -------------------------------------------- */
+/*  Bundled Module Exports                      */
+/* -------------------------------------------- */
+
+export {
+  applications,
+  canvas,
+  dataModels,
+  dice,
+  documents,
+  enrichers,
+  Filter,
+  migrations,
+  registry,
+  utils,
+  DND5E
+};


### PR DESCRIPTION
## Summary
- replace the manifest metadata to publish the Wizards & Shadows system
- add the Wizards & Shadows entrypoint module that wires configuration and hook handlers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9bd67039c8330b0596f8708e430d4